### PR TITLE
Update bundler to 2.5.10

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,11 @@
 source 'https://rubygems.org'
 
+gem "csv"
+gem "base64"
+gem "bigdecimal"
+gem "faraday-retry"
 gem 'jekyll'
+gem "jekyll-sass-converter", "2.1.0"
 
 group :jekyll_plugins do
   gem 'jekyll-gist'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -127,4 +127,4 @@ DEPENDENCIES
   rspec
 
 BUNDLED WITH
-   2.1.4
+   2.5.10

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,10 +4,13 @@ GEM
     addressable (2.8.6)
       public_suffix (>= 2.0.2, < 6.0)
     asciidoctor (1.5.8)
+    base64 (0.2.0)
+    bigdecimal (3.1.7)
     byebug (11.1.3)
     coderay (1.1.1)
     colorator (1.1.0)
     concurrent-ruby (1.2.3)
+    csv (3.3.0)
     diff-lcs (1.5.1)
     em-websocket (0.5.3)
       eventmachine (>= 0.12.9)
@@ -17,9 +20,9 @@ GEM
       faraday-net_http (>= 2.0, < 3.2)
     faraday-net_http (3.1.0)
       net-http
+    faraday-retry (1.0.3)
     ffi (1.16.3)
     forwardable-extended (2.6.0)
-    google-protobuf (3.25.3)
     http_parser.rb (0.8.0)
     i18n (1.14.4)
       concurrent-ruby (~> 1.0)
@@ -45,8 +48,8 @@ GEM
     jekyll-gist (1.5.0)
       octokit (~> 4.2)
     jekyll-paginate (1.1.0)
-    jekyll-sass-converter (3.0.0)
-      sass-embedded (~> 1.54)
+    jekyll-sass-converter (2.1.0)
+      sassc (> 2.0.1, < 3.0)
     jekyll-watch (2.2.1)
       listen (~> 3.0)
     kramdown (2.4.0)
@@ -78,7 +81,6 @@ GEM
       pry (>= 0.13, < 0.15)
     public_suffix (5.0.4)
     racc (1.7.3)
-    rake (13.1.0)
     rb-fsevent (0.11.2)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
@@ -99,9 +101,8 @@ GEM
       rspec-support (~> 3.13.0)
     rspec-support (3.13.1)
     safe_yaml (1.0.5)
-    sass-embedded (1.71.1)
-      google-protobuf (~> 3.25)
-      rake (>= 13.0.0)
+    sassc (2.4.0)
+      ffi (~> 1.9)
     sawyer (0.9.2)
       addressable (>= 2.3.5)
       faraday (>= 0.17.3, < 3)
@@ -117,11 +118,16 @@ PLATFORMS
 
 DEPENDENCIES
   asciidoctor (~> 1.5.4)
+  base64
+  bigdecimal
   coderay (= 1.1.1)
+  csv
+  faraday-retry
   jekyll
   jekyll-asciidoc
   jekyll-gist
   jekyll-paginate
+  jekyll-sass-converter (= 2.1.0)
   nokogiri
   pry-byebug
   rspec


### PR DESCRIPTION
This updates bundler and adds gems which are no longer included by default in later versions of ruby.